### PR TITLE
Compatibility with older glibc (centos 5, glibc 2.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ LIBDIRS ?=
 
 CC = gcc
 CFLAGS = --std=gnu99 -fPIC -O2 -g -ggdb -Wall
+ifneq (, $(findstring gaih_addrtuple, $(shell grep gaih_addrtuple /usr/include/nss.h)))
+CFLAGS += -DHAVE_GETHOSTBYNAME4=1
+endif
+
 LDFLAGS = -l$(LIBUNBOUND) $(LIBDIRS)
 STATIC_LDFLAGS = -Wl,-Bstatic -l$(LIBUNBOUND) -lldns -Wl,-Bdynamic -lcrypto -lpthread $(LIBDIRS)
 

--- a/nss-ubdns.c
+++ b/nss-ubdns.c
@@ -52,12 +52,14 @@
 
 #define ALIGN(a) (((a+sizeof(void*)-1)/sizeof(void*))*sizeof(void*))
 
+#ifdef HAVE_GETHOSTBYNAME4
 enum nss_status _nss_ubdns_gethostbyname4_r(
 		const char *name,
 		struct gaih_addrtuple **pat,
 		char *buffer, size_t buflen,
 		int *errnop, int *h_errnop,
 		int32_t *ttlp);
+#endif
 
 enum nss_status _nss_ubdns_gethostbyname3_r(
 		const char *name,
@@ -96,6 +98,7 @@ enum nss_status _nss_ubdns_gethostbyaddr_r(
 		char *buffer, size_t buflen,
 		int *errnop, int *h_errnop);
 
+#ifdef HAVE_GETHOSTBYNAME4
 enum nss_status _nss_ubdns_gethostbyname4_r(
 		const char *hn,
 		struct gaih_addrtuple **pat,
@@ -156,6 +159,7 @@ enum nss_status _nss_ubdns_gethostbyname4_r(
 
 	return NSS_STATUS_SUCCESS;
 }
+#endif
 
 enum nss_status _nss_ubdns_gethostbyname3_r(
 		const char *hn,


### PR DESCRIPTION
Less controversial than my first pull request :)

On older glibc, gaih_addrtuple doesn't exist and gethostbyname4 is thus
not needed. The test in the makefile is the best I could come up with,
lacking a proper ./configure.

Tested & working on centos 5 (old glibc) and 6 (new glibc)
